### PR TITLE
Remove all empty directories from entire Desktop

### DIFF
--- a/desktop-cleaner.bash
+++ b/desktop-cleaner.bash
@@ -23,8 +23,13 @@ symlink="$HOME/Desktop/current"
 
 # Remove empty dirs.
 # This needs to be done before save/storage/current are init'd
-empty_dirs=$(find ${storage} -maxdepth 3 -type d -empty)
-for dir in $empty_dirs; do rmdir ${dir}; done
+while read dir
+do
+  while read emptyDir
+  do
+    [ "$emptyDir" != "" ] && [ "$emptyDir" != "$clean" ] && rmdir $emptyDir
+  done <<< "$(find $dir -maxdepth 0 -empty)"
+done <<< "$(find $clean -type d | tac)"
 
 # Create all folders if they don't exist
 [ ! -d ${save} ] && mkdir -p ${save}


### PR DESCRIPTION
By piping the results of the `find` command to `tac`, we get the results in reverse, like so:
```
/User/dfelton/Desktop/foo/bar
/User/dfelton/Desktop/foo
```
This allows us to then essentially "recursively remove empty directories", as once all sub-directories of a directory are removed, if THAT directory is also now empty, it gets removed as well.

Additional check added to ensure we don't actually delete our desktop.

Enjoy your clean(er) desktop, dewd. :)